### PR TITLE
options/internal: improve overlap checking for memmove

### DIFF
--- a/options/internal/generic/essential.cpp
+++ b/options/internal/generic/essential.cpp
@@ -194,7 +194,7 @@ void *memmove(void *dest, const void *src, size_t size) {
 	uintptr_t udest = reinterpret_cast<uintptr_t>(dest);
 	uintptr_t usrc = reinterpret_cast<uintptr_t>(src);
 
-	if(udest < usrc || usrc + size <= udest) {
+	if(udest < usrc || udest - usrc >= size) {
 		return forward_copy(dest, src, size);
 	} else if(udest > usrc) {
 		char *dest_bytes = (char *)dest;


### PR DESCRIPTION
The current condition fails to account for `memmove (-1, -2, 2)`.  While realistically the last page is not going to be accessible in user mode and the first is unlikely to be mapped, it’s still bad form for generic code, plus there is the niche use case of emulating accesses from a SIGSEGV handler using `siginfo_t`.  Another corner case is when `src == dest && size >= -src`, which should be a noop.